### PR TITLE
Fix: Telegram's link preview was spending the magic link before the user

### DIFF
--- a/admin_panel.py
+++ b/admin_panel.py
@@ -965,6 +965,25 @@ def email_verify_code():
 # that gets the token out of the address bar.
 MAGIC_LINK_MAX_AGE_SECONDS = 600
 
+# Link-preview crawlers fetch a URL the moment it appears in a message, which on
+# a single-use token means it is spent before the human ever taps it. That is
+# exactly what happened in production: Telegram's crawler took the link at
+# 01:15:17 and the user's iPhone got "already used" at 01:15:23.
+#
+# The preview is disabled on the bot's side now, so this should never fire. It
+# stays because any client, forwarded chat or link-scanning service can prefetch
+# a URL, and a login that breaks on the first click is not worth risking twice.
+# These requests get no session and never touch the token, so a forged user
+# agent buys an attacker nothing.
+_PREFETCH_AGENTS = ("telegrambot", "twitterbot", "facebookexternalhit", "whatsapp",
+                    "slackbot", "discordbot", "linkedinbot", "skypeuripreview",
+                    "bingbot", "googlebot", "embedly", "vkshare", "preview")
+
+
+def _is_link_prefetch(user_agent: str) -> bool:
+    agent = (user_agent or "").lower()
+    return any(crawler in agent for crawler in _PREFETCH_AGENTS)
+
 
 @app.route("/auth/magic")
 def magic_login():
@@ -978,6 +997,17 @@ def magic_login():
     token = request.args.get("token")
     if not token:
         return "کد ورود (Token) ارسال نشده است.", 400
+
+    if _is_link_prefetch(request.headers.get("User-Agent", "")):
+        # Enough for a preview to render, without spending the token or
+        # handing out a session.
+        return Response(
+            "<!doctype html><title>Gheychi Premium</title>"
+            "<meta name=\"robots\" content=\"noindex\">"
+            "<p>Open this link in your browser to sign in.</p>",
+            status=200,
+            mimetype="text/html",
+        )
 
     serializer = URLSafeTimedSerializer(FLASK_SECRET_KEY)
     try:

--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,7 @@ from telegram import (
     Update,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    LinkPreviewOptions,
     Message,
 )
 from telegram.ext import (
@@ -446,6 +447,9 @@ async def handle_utility_callback(query, context: ContextTypes.DEFAULT_TYPE):
             reply_markup=InlineKeyboardMarkup(
                 [[InlineKeyboardButton(get_text("btn_dashboard", user_lang), url=dashboard_url)]]
             ),
+            # Telegram's preview crawler opens any URL in the message body. On a
+            # single-use link that spends the token before the user taps it.
+            link_preview_options=LinkPreviewOptions(is_disabled=True),
         )
         return
     if action == "myid":
@@ -1149,7 +1153,8 @@ async def dashboard_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     keyboard = [[InlineKeyboardButton(get_text("btn_dashboard", user_lang), url=dashboard_url)]]
     await update.message.reply_text(
         get_text("login_link", user_lang, link=dashboard_url),
-        reply_markup=InlineKeyboardMarkup(keyboard)
+        reply_markup=InlineKeyboardMarkup(keyboard),
+        link_preview_options=LinkPreviewOptions(is_disabled=True),
     )
 
 async def handle_lang_callback(query, context: ContextTypes.DEFAULT_TYPE):

--- a/tests/test_magic_prefetch.py
+++ b/tests/test_magic_prefetch.py
@@ -1,0 +1,100 @@
+"""
+Regression tests for the link-preview crawler burning a single-use magic link.
+
+Production log, 2026-09-07:
+  01:15:17  "TelegramBot (like TwitterBot)"  -> 302   token spent
+  01:15:23  "Mozilla/5.0 (iPhone ...) Safari" -> 401   user locked out
+"""
+import os
+import sys
+import secrets
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+TELEGRAM_CRAWLER = "TelegramBot (like TwitterBot)"
+IPHONE = ("Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 "
+          "(KHTML, like Gecko) Version/26.6.1 Mobile/23G83 Safari/604.1")
+
+
+class MagicLinkPrefetchTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        os.environ["ADMIN_PASSWORD"] = "test-admin-pw"
+        import runtime_store
+        runtime_store.LOGS_DB = Path(cls.tmp.name) / "prefetch.db"
+        runtime_store.DATA_DIR = Path(cls.tmp.name)
+        runtime_store.init_logs_db()
+        import admin_panel
+        admin_panel.app.config["TESTING"] = True
+        cls.ap = admin_panel
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def setUp(self):
+        import runtime_store
+        with runtime_store._connect() as conn:
+            for t in ("accounts", "account_telegram_links", "consumed_auth_tokens",
+                      "rate_limits", "bot_users", "link_cooldowns"):
+                conn.execute(f"DELETE FROM {t}")
+            conn.commit()
+        runtime_store.upsert_bot_user(425864094, username="u", first_name="F",
+                                      last_name=None, language_code="fa")
+
+    def _token(self):
+        from itsdangerous import URLSafeTimedSerializer
+        from config import FLASK_SECRET_KEY
+        ser = URLSafeTimedSerializer(FLASK_SECRET_KEY)
+        return ser.dumps({"uid": 425864094, "jti": secrets.token_urlsafe(16)}, salt="magic-link")
+
+    def test_the_telegram_crawler_does_not_spend_the_token(self):
+        """The exact sequence that locked the user out, replayed."""
+        token = self._token()
+        crawler = self.ap.app.test_client()
+        r1 = crawler.get(f"/auth/magic?token={token}", headers={"User-Agent": TELEGRAM_CRAWLER})
+        self.assertEqual(r1.status_code, 200)
+
+        user = self.ap.app.test_client()
+        r2 = user.get(f"/auth/magic?token={token}", headers={"User-Agent": IPHONE})
+        self.assertEqual(r2.status_code, 302, "the human must still be able to sign in")
+        self.assertIn("/dashboard", r2.headers.get("Location", ""))
+
+    def test_the_crawler_is_never_handed_a_session(self):
+        token = self._token()
+        crawler = self.ap.app.test_client()
+        crawler.get(f"/auth/magic?token={token}", headers={"User-Agent": TELEGRAM_CRAWLER})
+        with crawler.session_transaction() as sess:
+            self.assertIsNone(sess.get("account_id"))
+            self.assertIsNone(sess.get("role"))
+        # And it stays locked out of everything a session would open.
+        self.assertEqual(crawler.get("/account/links").status_code, 401)
+
+    def test_a_real_browser_still_burns_the_token_once(self):
+        token = self._token()
+        first = self.ap.app.test_client()
+        self.assertEqual(first.get(f"/auth/magic?token={token}", headers={"User-Agent": IPHONE}).status_code, 302)
+        second = self.ap.app.test_client()
+        self.assertEqual(second.get(f"/auth/magic?token={token}", headers={"User-Agent": IPHONE}).status_code, 401)
+
+    def test_other_common_preview_crawlers_are_recognised(self):
+        for agent in ("WhatsApp/2.23", "facebookexternalhit/1.1", "Slackbot-LinkExpanding 1.0",
+                      "Discordbot/2.0", "Twitterbot/1.0", "LinkedInBot/1.0"):
+            with self.subTest(agent=agent):
+                self.assertTrue(self.ap._is_link_prefetch(agent))
+
+    def test_ordinary_browsers_are_not_mistaken_for_crawlers(self):
+        for agent in (IPHONE,
+                      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/141.0 Safari/537.36",
+                      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Firefox/155.0",
+                      ""):
+            with self.subTest(agent=agent):
+                self.assertFalse(self.ap._is_link_prefetch(agent))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Tapping the dashboard link from the bot gave **"این لینک قبلاً استفاده شده است"** on the very first click. The production log shows why:

```
01:15:17  "TelegramBot (like TwitterBot)"    GET /auth/magic  302
01:15:23  "Mozilla/5.0 (iPhone ...) Safari"  GET /auth/magic  401
```

Telegram opens any URL in a message body to build its preview card. Phase 0 made the link single-use to stop replay from chat history. Together those two facts mean the crawler spends the token six seconds before the person can use it — **every dashboard link the bot has sent since that deploy has been dead on arrival.**

This is the same prefetch risk the Phase 0 commit named as a reason to burn the token, and then did not defend against. My miss.

## Two layers

1. **The bot no longer lets Telegram fetch it.** Both magic-link messages send with `link_preview_options(is_disabled=True)`.
2. **`/auth/magic` refuses to spend a token for a crawler.** Known preview agents get a small static page — no token consumed, no session issued. Kept as belt and braces because any client, forwarded chat, or link-scanning service can prefetch a URL, and a login that breaks on first click is not worth risking twice.

A forged user agent buys an attacker nothing: that path hands out no session at all.

## Tests

60 passing. Five new ones replay the exact production sequence, assert the crawler is never handed a session and stays locked out of `/account/links`, confirm a real browser still burns the token exactly once, and check that iPhone, Chrome and Firefox agents are not mistaken for crawlers.