### PR TITLE
Fix: back up once a day, not once per container start

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -11,6 +11,7 @@
 زیرساختی که این پروژه از قبل دارد.
 """
 import asyncio
+import json
 import logging
 import os
 import sqlite3
@@ -33,7 +34,12 @@ TELEGRAM_UPLOAD_LIMIT_BYTES = 50 * 1024 * 1024
 # Cookie files are re-created from the COOKIES_*_B64 env vars on every boot, so
 # they are recoverable without a backup — and they are login credentials for
 # other people's sites. Keeping them out means the archive holds no secrets.
+# Operational bookkeeping, not data — keeping it out means restoring an archive
+# cannot resurrect a stale "last backup" time and skip the next one.
+STATE_FILE = "backup_state.json"
+
 _EXCLUDED_PREFIXES = ("cookies_",)
+_EXCLUDED_NAMES = (STATE_FILE,)
 
 # The -wal and -shm sidecars belong to the *live* database. Their contents are
 # already folded into the snapshot the backup API produces, and shipping a stale
@@ -77,6 +83,8 @@ def build_backup_archive(dest_dir: str) -> Path:
         for entry in sorted(data_dir.iterdir()):
             if not entry.is_file() or entry.name.startswith(_EXCLUDED_PREFIXES):
                 continue
+            if entry.name in _EXCLUDED_NAMES:
+                continue
             if entry.name.endswith(_EXCLUDED_SUFFIXES):
                 continue
             if entry.suffix == ".db":
@@ -90,6 +98,46 @@ def build_backup_archive(dest_dir: str) -> Path:
             else:
                 zipf.write(entry, entry.name)
     return archive
+
+
+def _state_path() -> Path:
+    return Path(DATA_DIR) / STATE_FILE
+
+
+def last_backup_at() -> datetime | None:
+    """
+    When the last archive was delivered, read from the volume.
+
+    Kept on disk rather than in memory because the whole point is to survive
+    the restart: the process starts fresh on every deploy and would otherwise
+    have no idea a backup was taken four minutes ago.
+    """
+    try:
+        raw = json.loads(_state_path().read_text(encoding="utf-8"))
+        return datetime.fromisoformat(raw["last_backup_at"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def _record_backup(moment: datetime) -> None:
+    try:
+        _state_path().write_text(
+            json.dumps({"last_backup_at": moment.isoformat()}), encoding="utf-8"
+        )
+    except OSError as exc:
+        # Losing this only costs an extra backup, so it must never take the
+        # successful upload down with it.
+        logger.warning("Backup: could not record the timestamp: %s", exc)
+
+
+def seconds_until_due(now: datetime | None = None) -> float:
+    """How long to wait before the next backup is due. 0 means overdue."""
+    now = now or datetime.now(timezone.utc)
+    previous = last_backup_at()
+    if previous is None:
+        return 0.0
+    elapsed = (now - previous).total_seconds()
+    return max(0.0, BACKUP_INTERVAL_SECONDS - elapsed)
 
 
 async def _upload(archive: Path, caption: str) -> None:
@@ -135,6 +183,7 @@ def run_backup_once() -> bool:
             logger.error("Backup: upload failed: %s", exc)
             return False
 
+    _record_backup(datetime.now(timezone.utc))
     logger.info("Backup: sent %s (%.0f KB)", archive.name, size / 1024)
     return True
 
@@ -151,6 +200,15 @@ def run_backup_loop() -> None:
         return
 
     while True:
+        # The loop used to back up the moment it started, which meant one
+        # archive per container start rather than one per interval — five in a
+        # night of deploys. A backup nobody reads is a backup nobody checks, so
+        # the schedule is honoured across restarts instead.
+        wait = seconds_until_due()
+        if wait > 0:
+            logger.info("Backup: last one was recent, next due in %.1f h", wait / 3600)
+            time.sleep(wait)
+            continue
         try:
             run_backup_once()
         except Exception as exc:

--- a/tests/test_backup_schedule.py
+++ b/tests/test_backup_schedule.py
@@ -1,0 +1,76 @@
+"""
+Regression tests: the backup fired on every container start, not every 24 h.
+
+Five deploys on the night of 2026-09-06 produced five archives in the channel
+within 90 minutes, because run_backup_loop() called run_backup_once() before
+its first sleep and a deploy restarts the process.
+"""
+import os
+import sys
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class BackupScheduleTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        import backup
+        self.backup = backup
+        self._orig_dir = backup.DATA_DIR
+        backup.DATA_DIR = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.backup.DATA_DIR = self._orig_dir
+        self.tmp.cleanup()
+
+    def _write_state(self, moment):
+        (Path(self.tmp.name) / self.backup.STATE_FILE).write_text(
+            json.dumps({"last_backup_at": moment.isoformat()}), encoding="utf-8")
+
+    def test_with_no_history_a_backup_is_due_immediately(self):
+        self.assertEqual(self.backup.seconds_until_due(), 0.0)
+
+    def test_a_restart_minutes_after_a_backup_does_not_trigger_another(self):
+        """The exact failure: deploy, restart, second archive four minutes later."""
+        now = datetime.now(timezone.utc)
+        self._write_state(now - timedelta(minutes=4))
+        wait = self.backup.seconds_until_due(now)
+        self.assertGreater(wait, 0)
+        self.assertAlmostEqual(wait, 24 * 3600 - 240, delta=2)
+
+    def test_a_backup_becomes_due_again_after_the_interval(self):
+        now = datetime.now(timezone.utc)
+        self._write_state(now - timedelta(hours=24, minutes=1))
+        self.assertEqual(self.backup.seconds_until_due(now), 0.0)
+
+    def test_a_long_outage_still_backs_up_on_return(self):
+        now = datetime.now(timezone.utc)
+        self._write_state(now - timedelta(days=9))
+        self.assertEqual(self.backup.seconds_until_due(now), 0.0)
+
+    def test_a_corrupt_or_missing_state_file_falls_back_to_backing_up(self):
+        # Better an extra archive than a silent gap.
+        (Path(self.tmp.name) / self.backup.STATE_FILE).write_text("{not json", encoding="utf-8")
+        self.assertIsNone(self.backup.last_backup_at())
+        self.assertEqual(self.backup.seconds_until_due(), 0.0)
+
+    def test_the_state_file_is_kept_out_of_the_archive(self):
+        import zipfile
+        self._write_state(datetime.now(timezone.utc))
+        (Path(self.tmp.name) / "plans.json").write_text("{}", encoding="utf-8")
+        with tempfile.TemporaryDirectory() as out:
+            archive = self.backup.build_backup_archive(out)
+            names = zipfile.ZipFile(archive).namelist()
+        # Restoring an archive must not resurrect a stale timestamp and cause
+        # the next backup to be skipped.
+        self.assertIn("plans.json", names)
+        self.assertNotIn(self.backup.STATE_FILE, names)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Five backup archives landed in the channel inside ninety minutes.

Not a malfunction — a consequence of how I wrote the loop:

```python
while True:
    run_backup_once()          # fires immediately on every process start
    time.sleep(BACKUP_INTERVAL_SECONDS)
```

A deploy restarts the process, so "every 24 hours" was really "on every boot, then every 24 hours". There were five deploys tonight, so five archives.

## Fix

The delivery time is written to `backup_state.json` on the volume, and on start the loop waits out the remainder of the interval instead of firing immediately.

Failure modes deliberately prefer an extra archive over a missing one:

| Situation | Behaviour |
|---|---|
| No state file, or corrupt | Back up now |
| Container down for days | Back up on return |
| Upload failed | Timestamp not written — retried next loop |
| Cannot write the timestamp | Logged, never fails the successful upload |

`backup_state.json` is excluded from the archive: restoring an old archive must not resurrect a stale timestamp and silently skip the next backup.

## Why it is worth fixing rather than tolerating

A channel that fills with archives nobody reads is a channel nobody checks — which is exactly how a broken backup goes unnoticed until the day it is needed.

## Verified

66 tests. Tonight's exact restart sequence replayed against the fix: **5 archives becomes 1**, and one still fires the next day.