### PR TITLE
Fix YouTube MP3 in production, and close the Stripe GET

### DIFF
--- a/admin_panel.py
+++ b/admin_panel.py
@@ -778,20 +778,11 @@ def _activate_paid_plan(telegram_user_id: int, plan_code: str, *, note: str, tx_
     return True
 
 
-@app.route('/webhook/stripe', methods=['GET', 'POST'])
+# POST only. Stripe never sends a GET, and the GET this route used to answer
+# told anyone, unauthenticated, whether the keys were set and the first seven
+# characters of the secret key.
+@app.route('/webhook/stripe', methods=['POST'])
 def stripe_webhook():
-    # GET: health-check / debug endpoint
-    if request.method == 'GET':
-        settings = load_settings()
-        has_key = bool(settings.get("stripe_secret_key") or STRIPE_SECRET_KEY)
-        has_wh = bool(settings.get("stripe_webhook_secret") or STRIPE_WEBHOOK_SECRET)
-        return jsonify({
-            "webhook": "ready",
-            "stripe_secret_key_set": has_key,
-            "stripe_webhook_secret_set": has_wh,
-            "secret_key_prefix": (settings.get("stripe_secret_key") or STRIPE_SECRET_KEY or "")[:7] + "..." if has_key else "MISSING",
-        }), 200
-
     payload = request.data
     sig_header = request.headers.get("Stripe-Signature")
 

--- a/downloader.py
+++ b/downloader.py
@@ -811,6 +811,38 @@ async def download_audio(
     loop = asyncio.get_running_loop()
     last_download_error: yt_dlp.utils.DownloadError | None = None
 
+    # YouTube audio goes to the provider first, the same way video does. yt-dlp
+    # cannot reach YouTube from this host at all, so trying it first only spent
+    # six failed profiles before the MP3 failed with them. It stays behind the
+    # provider as a fallback, and every other site is untouched.
+    if _is_youtube_url(source_url):
+        api_result = await loop.run_in_executor(None, lambda: get_direct_media_url(source_url, "audio"))
+        if api_result.get("success"):
+            destination = download_dir / f"{request_id}.mp3"
+            try:
+                def _do_download():
+                    def _safe_progress(pct: int):
+                        if progress_callback:
+                            loop.call_soon_threadsafe(progress_callback, pct)
+                    _download_file(api_result["url"], destination, _safe_progress)
+                await loop.run_in_executor(None, _do_download)
+                if destination.exists() and destination.stat().st_size > 0:
+                    if destination.stat().st_size > max_file_size_bytes:
+                        destination.unlink(missing_ok=True)
+                        return DownloadResult(
+                            success=False,
+                            error=f"فایل بزرگتر از {max_file_size_bytes // (1024*1024)} مگابایت است.",
+                        )
+                    return DownloadResult(
+                        success=True, file_path=str(destination), title="صوت",
+                        source=api_result.get("source", "API"),
+                        duration=_extract_audio_duration(str(destination)),
+                    )
+            except Exception as e:
+                logger.error("YouTube audio via the provider failed: %s", e)
+        else:
+            logger.warning("YouTube audio provider failed: %s. Falling back to yt-dlp...", api_result.get("error"))
+
     for profile in _youtube_ydl_profiles(source_url):
         opts = _base_ydl_opts(
             output_template,


### PR DESCRIPTION
Two P1 items from the Gheychee Board.

## YouTube MP3 failed in production
`download_audio` used yt-dlp only, and YouTube blocks yt-dlp from Railway. Audio now goes through the RapidAPI provider (`format=mp3`) first, with yt-dlp as the fallback. Other sites are untouched.

## `GET /webhook/stripe` exposed key details
Without authentication it said whether the keys were set and returned the first 7 characters of the secret key. The route is now POST only (GET → 404). Stripe only sends POST, and that behaviour is unchanged.

## Verified
- YouTube → 8.2 MB MP3 (codec mp3) via `RapidAPI (YouTube)`
- RadioJavan and SoundCloud audio unchanged
- GET → 404 with no key data; POST without signature → 400 as before
- 66/66 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)