### PR TITLE
Ready-to-do sweep: account quota pool, quota alert, generator, clean HTML

### DIFF
--- a/accounts.py
+++ b/accounts.py
@@ -16,7 +16,7 @@ from datetime import timedelta
 from typing import Any
 
 from plans import get_max_linked_accounts
-from runtime_store import _connect, _parse_datetime, _utc_datetime, _utc_now, init_logs_db
+from runtime_store import _connect, _parse_datetime, _utc_datetime, _utc_now, account_effective_plan_code, init_logs_db
 
 UNLINK_COOLDOWN_DAYS = 7
 
@@ -179,19 +179,11 @@ def _active_cooldown(conn, account_id: str, telegram_user_id: int) -> str | None
 
 def account_plan_code(account_id: str) -> str:
     """
-    The plan this account is entitled to.
-
-    Phase 1 still stores the plan on bot_users, so the account's plan is the
-    best one among its linked Telegram accounts. Phase 2 moves the column onto
-    accounts and this becomes a plain read.
+    The plan this account is entitled to: the best active plan among its linked
+    Telegram accounts. Expiry counts, so a lapsed plan no longer props up the
+    slot cap. The same resolution runs in the download gate.
     """
-    order = {"free": 0, "starter": 1, "standard": 2, "pro": 3}
-    best = "free"
-    for link in list_links(account_id):
-        code = link.get("plan_code") or "free"
-        if order.get(code, 0) > order.get(best, 0):
-            best = code
-    return best
+    return account_effective_plan_code(account_id)
 
 
 def link_telegram(account_id: str, telegram_user_id: int) -> None:
@@ -231,6 +223,12 @@ def link_telegram(account_id: str, telegram_user_id: int) -> None:
         conn.execute(
             "INSERT INTO account_telegram_links (telegram_user_id, account_id, linked_at) VALUES (?, ?, ?)",
             (telegram_user_id, account_id, _utc_now()),
+        )
+        # Usage from before the link joins the account's pool, so linking a
+        # Telegram account that has spent its own allowance cannot reset it.
+        conn.execute(
+            "UPDATE usage_events SET account_id = ? WHERE telegram_user_id = ? AND account_id IS NULL",
+            (account_id, telegram_user_id),
         )
         # Relinking the same Telegram account should not be punished, so its own
         # cooldown rows are cleared. Only a *different* account taking the freed

--- a/api_client.py
+++ b/api_client.py
@@ -215,6 +215,54 @@ def fetch_media_from_rapidapi(url: str) -> dict:
         logger.error(f"RapidAPI Error: {str(e)}")
         return {"success": False, "error": f"خطا در ارتباط با RapidAPI: {str(e)[:100]}"}
 
+YOUTUBE_QUOTA_ALERT_UNITS = int(os.getenv("YOUTUBE_QUOTA_ALERT_UNITS", "100"))
+
+
+def _maybe_alert_low_quota(remaining) -> None:
+    """
+    Tell the operator, once a day, when the YouTube provider is close to its
+    daily allowance, in the backup channel they already watch. At four units a
+    download the default of 100 leaves about 25 downloads. Past zero the
+    provider refuses and YouTube links fail until the reset.
+
+    Every failure here is logged and dropped: an alert must never cost a download.
+    """
+    try:
+        left = int(remaining)
+    except (TypeError, ValueError):
+        return
+    if left > YOUTUBE_QUOTA_ALERT_UNITS:
+        return
+    import json as _json
+    import urllib.parse
+    from datetime import datetime, timezone
+    from pathlib import Path
+    from config import BOT_TOKEN, DATA_DIR, normalise_channel_id
+    channel = normalise_channel_id(os.getenv("BACKUP_CHANNEL_ID", ""))
+    if not (BOT_TOKEN and channel):
+        logger.warning("YouTube API units low (%s) and no BACKUP_CHANNEL_ID to alert", left)
+        return
+    state = Path(DATA_DIR) / "youtube_quota_alert.json"
+    today = datetime.now(timezone.utc).date().isoformat()
+    try:
+        if state.exists() and _json.loads(state.read_text()).get("date") == today:
+            return
+    except (OSError, ValueError):
+        pass
+    text = (f"⚠️ YouTube API: {left} units left today, about {left // 4} downloads. "
+            "Past zero, YouTube links fail until the daily reset. "
+            "If this keeps happening, upgrade the RapidAPI plan.")
+    try:
+        body = urllib.parse.urlencode({"chat_id": channel, "text": text}).encode()
+        with urlopen(Request(f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage", data=body), timeout=15):
+            pass
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text(_json.dumps({"date": today, "remaining": left}))
+        logger.warning("YouTube API units low (%s): alert sent to the backup channel", left)
+    except Exception as e:
+        logger.warning("could not send the YouTube quota alert: %s", e)
+
+
 def fetch_media_from_youtube_fast_api(url: str, quality: str) -> dict:
     """
     Last resort for YouTube, reached only after every yt-dlp profile has failed.
@@ -266,6 +314,7 @@ def fetch_media_from_youtube_fast_api(url: str, quality: str) -> dict:
             # Roughly four units a request against a daily allowance, so this is
             # the number to watch before YouTube starts failing on quota alone.
             logger.info("YouTube API units remaining: %s", remaining)
+            _maybe_alert_low_quota(remaining)
 
         progress_url = job.get("progress_url")
         if not progress_url:

--- a/runtime_store.py
+++ b/runtime_store.py
@@ -336,6 +336,21 @@ def init_logs_db() -> None:
             except sqlite3.OperationalError:
                 pass  # Column already exists
 
+        # Model C: the quota pool belongs to the account, so each event records
+        # the account it was drawn from. Stamped at write time rather than looked
+        # up through the current links, so unlinking a Telegram account cannot
+        # hand its usage back. Existing rows are stamped once, when the column
+        # is first added.
+        try:
+            conn.execute("ALTER TABLE usage_events ADD COLUMN account_id TEXT")
+            conn.execute(
+                "UPDATE usage_events SET account_id = (SELECT l.account_id FROM account_telegram_links l "
+                "WHERE l.telegram_user_id = usage_events.telegram_user_id) WHERE account_id IS NULL"
+            )
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_usage_account ON usage_events (account_id, created_at)")
+
         conn.commit()
 
 
@@ -570,6 +585,76 @@ def _row_to_user(row: sqlite3.Row | None) -> dict[str, Any] | None:
     return user
 
 
+_PLAN_ORDER = {"free": 0, "starter": 1, "standard": 2, "pro": 3}
+
+
+def _linked_account_id(conn, telegram_user_id: int) -> str | None:
+    row = conn.execute(
+        "SELECT account_id FROM account_telegram_links WHERE telegram_user_id = ?", (telegram_user_id,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _usage_scope(conn, telegram_user_id: int) -> tuple[str, tuple]:
+    """
+    Which usage events a quota check counts. A Telegram account linked to a web
+    account draws on that account's pool, so every linked ID shares one
+    allowance. One that is not linked counts only its own events, as before.
+    """
+    account_id = _linked_account_id(conn, telegram_user_id)
+    if account_id:
+        return "account_id = ?", (account_id,)
+    return "telegram_user_id = ?", (telegram_user_id,)
+
+
+def account_effective_plan_code(account_id: str) -> str:
+    """
+    The plan an account is entitled to: the best active plan among its linked
+    Telegram accounts. An expired plan counts as free, so a lapsed subscription
+    can no longer hold a slot cap or a quota open.
+    """
+    init_logs_db()
+    with closing(_connect()) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT u.telegram_user_id, u.username, u.first_name, u.last_name, u.language_code, u.plan_code,
+                   u.plan_started_at, u.plan_expires_at, u.assigned_note, u.created_at, u.updated_at
+            FROM account_telegram_links l JOIN bot_users u ON u.telegram_user_id = l.telegram_user_id
+            WHERE l.account_id = ?
+            """,
+            (account_id,),
+        ).fetchall()
+    best = "free"
+    for row in rows:
+        code = _row_to_user(row)["effective_plan_code"]
+        if _PLAN_ORDER.get(code, 0) > _PLAN_ORDER.get(best, 0):
+            best = code
+    return best
+
+
+def _with_account_plan(user: dict[str, Any]) -> dict[str, Any]:
+    """
+    Model C: the plan belongs to the account. A Telegram account linked to a web
+    account is entitled to the best active plan among every Telegram account
+    linked there, so paying on one covers the others. The Telegram account's own
+    assignment stays in plan_code / assigned_plan for the admin panel.
+    """
+    if not user:
+        return user
+    with closing(_connect()) as conn:
+        account_id = _linked_account_id(conn, user["telegram_user_id"])
+    user["account_id"] = account_id
+    user["plan_via_account"] = False
+    if account_id:
+        best = account_effective_plan_code(account_id)
+        if _PLAN_ORDER.get(best, 0) > _PLAN_ORDER.get(user["effective_plan_code"], 0):
+            user["effective_plan_code"] = best
+            user["effective_plan"] = get_plan(best)
+            user["plan_via_account"] = True
+    return user
+
+
 def get_bot_user(telegram_user_id: int) -> dict[str, Any]:
     init_logs_db()
     with closing(_connect()) as conn:
@@ -586,7 +671,7 @@ def get_bot_user(telegram_user_id: int) -> dict[str, Any]:
     if row is None:
         upsert_bot_user(telegram_user_id)
         return get_bot_user(telegram_user_id)
-    return _row_to_user(row) or {}
+    return _with_account_plan(_row_to_user(row) or {})
 
 
 def assign_user_plan(
@@ -691,8 +776,8 @@ def record_usage_event(
                 telegram_user_id, created_at, plan_code, platform, url,
                 media_kind, quality, duration_seconds, metadata,
                 delivery_chat_id, delivery_message_id, delivery_file_id, delivery_kind,
-                delivery_source_chat_id, delivery_source_message_id, file_size_bytes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                delivery_source_chat_id, delivery_source_message_id, file_size_bytes, account_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 telegram_user_id,
@@ -711,6 +796,7 @@ def record_usage_event(
                 delivery.get("source_chat_id"),
                 delivery.get("source_message_id"),
                 delivery.get("file_size_bytes"),
+                _linked_account_id(conn, telegram_user_id),
             ),
         )
         conn.commit()
@@ -725,13 +811,14 @@ def count_usage_events(
     init_logs_db()
     period_from = _period_start(period).isoformat()
     with closing(_connect()) as conn:
+        scope, args = _usage_scope(conn, telegram_user_id)
         row = conn.execute(
-            """
+            f"""
             SELECT COUNT(*) AS total
             FROM usage_events
-            WHERE telegram_user_id = ? AND platform = ? AND created_at >= ?
+            WHERE {scope} AND platform = ? AND created_at >= ?
             """,
-            (telegram_user_id, platform, period_from),
+            (*args, platform, period_from),
         ).fetchone()
     return int(row[0] if row else 0)
 
@@ -750,10 +837,11 @@ def count_rule_usage(telegram_user_id: int, rule: dict) -> int:
     period_from = _period_start(rule["period"]).isoformat()
     marks = ",".join("?" for _ in named) or "''"
     with closing(_connect()) as conn:
+        scope, args = _usage_scope(conn, telegram_user_id)
         row = conn.execute(
-            f"SELECT COUNT(*) FROM usage_events WHERE telegram_user_id = ? AND created_at >= ? "
+            f"SELECT COUNT(*) FROM usage_events WHERE {scope} AND created_at >= ? "
             f"AND LOWER(platform) NOT IN ({marks})",
-            (telegram_user_id, period_from, *named),
+            (*args, period_from, *named),
         ).fetchone()
     return int(row[0] if row else 0)
 

--- a/tests/test_account_pool.py
+++ b/tests/test_account_pool.py
@@ -1,0 +1,128 @@
+"""
+Model C, phase 2: the plan and the quota belong to the account.
+
+A Telegram account linked to a web account gets the best active plan among the
+Telegram accounts linked there, and every linked ID draws on one quota pool.
+One that is not linked behaves exactly as it did before accounts existed.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from datetime import timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class AccountPoolTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        os.environ["DATA_DIR"] = cls.tmp.name
+        import runtime_store
+        from pathlib import Path
+        runtime_store.LOGS_DB = Path(cls.tmp.name) / "test.db"
+        runtime_store.DATA_DIR = Path(cls.tmp.name)
+        runtime_store.init_logs_db()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def setUp(self):
+        import runtime_store
+        with runtime_store._connect() as conn:
+            for t in ("accounts", "account_telegram_links", "link_cooldowns", "bot_users", "usage_events"):
+                conn.execute(f"DELETE FROM {t}")
+            conn.commit()
+
+    # helpers
+    def _user(self, tg, plan=None):
+        import runtime_store
+        runtime_store.upsert_bot_user(tg, language_code="en")
+        if plan:
+            runtime_store.assign_user_plan(tg, plan)
+
+    def _use(self, tg, platform, n):
+        import runtime_store
+        for _ in range(n):
+            runtime_store.record_usage_event(tg, platform=platform)
+
+    def _account(self, *tgs):
+        import accounts
+        a = accounts.create_account()
+        for tg in tgs:
+            accounts.link_telegram(a["account_id"], tg)
+        return a["account_id"]
+
+    # tests
+    def test_an_unlinked_telegram_account_behaves_as_before(self):
+        import runtime_store
+        self._user(501, "standard")
+        self._use(501, "YouTube", 3)
+        user = runtime_store.get_bot_user(501)
+        self.assertEqual(user["effective_plan_code"], "standard")
+        self.assertIsNone(user["account_id"])
+        self.assertEqual(runtime_store.count_usage_events(501, platform="YouTube", period="month"), 3)
+
+    def test_paying_on_one_linked_account_covers_the_others(self):
+        import runtime_store
+        self._user(601, "standard"); self._user(602)
+        self._account(601, 602)
+        user = runtime_store.get_bot_user(602)
+        self.assertEqual(user["effective_plan_code"], "standard")
+        self.assertTrue(user["plan_via_account"])
+        self.assertEqual(user["plan_code"], "free", "the second account's own assignment is untouched")
+
+    def test_an_expired_plan_does_not_cover_anyone(self):
+        import accounts, runtime_store
+        self._user(701, "pro"); self._user(702)
+        aid = self._account(701)
+        with runtime_store._connect() as conn:
+            past = (runtime_store._utc_datetime() - timedelta(days=1)).isoformat()
+            conn.execute("UPDATE bot_users SET plan_expires_at = ? WHERE telegram_user_id = 701", (past,))
+            conn.commit()
+        self.assertEqual(accounts.account_plan_code(aid), "free")
+        self.assertEqual(runtime_store.get_bot_user(701)["effective_plan_code"], "free")
+
+    def test_linked_accounts_share_one_quota(self):
+        import runtime_store
+        self._user(801, "standard"); self._user(802)
+        self._account(801, 802)
+        self._use(801, "YouTube", 6); self._use(802, "YouTube", 4)   # Standard: 10 YouTube a month
+        for tg in (801, 802):
+            self.assertEqual(runtime_store.count_usage_events(tg, platform="YouTube", period="month"), 10)
+            self.assertFalse(runtime_store.evaluate_download_access(tg, platform="YouTube")["allowed"])
+
+    def test_unlinking_does_not_hand_usage_back(self):
+        import accounts, runtime_store
+        self._user(901, "standard"); self._user(902)
+        aid = self._account(901, 902)
+        self._use(901, "YouTube", 6); self._use(902, "YouTube", 4)
+        accounts.unlink_telegram(aid, 902)
+        self.assertEqual(runtime_store.count_usage_events(901, platform="YouTube", period="month"), 10)
+        self.assertFalse(runtime_store.evaluate_download_access(901, platform="YouTube")["allowed"])
+
+    def test_linking_brings_earlier_usage_into_the_pool(self):
+        import runtime_store
+        self._user(1001, "standard"); self._user(1002)
+        self._use(1002, "YouTube", 3)                                   # spent before it was linked
+        self._account(1001, 1002)
+        self._use(1001, "YouTube", 7)
+        self.assertEqual(runtime_store.count_usage_events(1001, platform="YouTube", period="month"), 10)
+
+    def test_the_other_sites_allowance_is_pooled_too(self):
+        import runtime_store
+        from config import OTHER_SITES_PLATFORM
+        self._user(1101, "standard"); self._user(1102)
+        self._account(1101, 1102)
+        self._use(1101, "BiliBili", 2); self._use(1102, "Bandcamp", 1)
+        # Built here rather than read from plans.json, which other test modules
+        # share and may have rewritten: this test is about the pool, not the plans.
+        rule = {"platform": OTHER_SITES_PLATFORM, "limit": 13, "period": "month"}
+        self.assertEqual(runtime_store.count_rule_usage(1101, rule), 3)
+        self.assertEqual(runtime_store.count_rule_usage(1102, rule), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/build_supported_sites.py
+++ b/tools/build_supported_sites.py
@@ -1,0 +1,550 @@
+"""
+Regenerate website/supported-sites.html and adult_sites.json from the installed yt-dlp.
+
+    .venv/bin/python tools/build_supported_sites.py
+
+Run it after every yt-dlp upgrade: the A to Z list and the adult filter are both
+tied to the extractor set of the version the bot runs. Review the diff before
+committing: a site that drops out of the list usually means yt-dlp marked its
+extractor broken.
+"""
+import collections
+import html
+import inspect
+import json
+import pathlib
+from urllib.parse import urlparse
+
+MULTI = {"co.uk","com.au","co.jp","com.br","co.kr","com.tr","co.in","com.mx","com.ar","co.nz","org.uk","ne.jp",
+         "or.jp","com.cn","com.tw","com.hk","co.za","com.sg","gov.uk","ac.uk","net.au","com.pl","co.il","com.ua"}
+BOT_OWN_ROUTES = {"radiojavan.com", "t.me", "x.com", "twitter.com"}   # served outside yt-dlp's test URLs
+SHORT_ALIASES = {"youtu.be", "redd.it", "dai.ly"}                      # the long domain is already listed
+
+
+def _registrable(host):
+    h = host.lower().split(":")[0]
+    for p in ("www.","m.","mobile.","player.","embed.","video.","videos.","web.","music.","tv.","live.","play.","open.","api."):
+        if h.startswith(p) and h.count(".") > 1:
+            h = h[len(p):]
+    parts = h.split(".")
+    if len(parts) >= 3 and ".".join(parts[-2:]) in MULTI:
+        return ".".join(parts[-3:])
+    return ".".join(parts[-2:]) if len(parts) >= 2 else h
+
+
+def _tests_of(ie):
+    tests = []
+    for key in ("_TESTS", "_TEST"):
+        v = ie.__dict__.get(key)
+        if isinstance(v, dict):
+            tests.append(v)
+        elif isinstance(v, list):
+            tests += [t for t in v if isinstance(t, dict)]
+    return tests
+
+
+def extract():
+    """
+    Domains of every yt-dlp extractor, taken from its own test URLs, split into
+    the public list and the adult filter.
+
+    - The public list covers working, visible extractors only.
+    - The adult filter covers every extractor, broken ones included: blocking a
+      site yt-dlp cannot currently read costs nothing, and it keeps the filter
+      from shrinking whenever an extractor is marked broken for a release.
+    - An extractor counts as adult when most of its test cases are 18+, not when
+      one is: YouTube, Reddit and Dailymotion each test an age-gated video.
+    - Uses the non-lazy classes, because the lazy ones carry no _TESTS. A few
+      frontend extractors pick a public instance at random when they are
+      imported, so the random module is seeded first to keep the output stable.
+    """
+    import random
+    random.seed(0)
+    import yt_dlp
+    from yt_dlp.extractor import _extractors as X
+    from yt_dlp.extractor.common import InfoExtractor
+
+    listed, all_clean, adult_dom, adult_ie = set(), set(), set(), set()
+    for name, ie in sorted(vars(X).items()):
+        if not (name.endswith("IE") and inspect.isclass(ie) and issubclass(ie, InfoExtractor)):
+            continue
+        tests = _tests_of(ie)
+        with_info = [t for t in tests if t.get("info_dict")]
+        is_adult = bool(with_info) and sum(t["info_dict"].get("age_limit") == 18 for t in with_info) > len(with_info) / 2
+        public = not (ie.IE_NAME.lower().startswith("generic") or getattr(ie, "IE_DESC", None) is False or not ie.working())
+        for t in tests:
+            u = t.get("url") or ""
+            if not u.startswith("http"):
+                continue
+            d = _registrable(urlparse(u).netloc)
+            if "." not in d or len(d) < 4:
+                continue
+            if is_adult:
+                adult_dom.add(d)
+            else:
+                all_clean.add(d)
+                if public:
+                    listed.add(d)
+        if is_adult:
+            adult_ie.update({ie.IE_NAME.split(":")[0].lower(), ie.ie_key().lower()})
+    adult_dom -= all_clean                                    # a domain a general extractor serves is not adult by itself
+    adult_dom = {d for d in adult_dom if "pornhub" not in d}  # PornHub has its own operator-set plan rules
+    adult_ie = {x for x in adult_ie if "pornhub" not in x}
+    sites = sorted((listed - SHORT_ALIASES) | BOT_OWN_ROUTES)
+    adult = {"source": f"yt-dlp {yt_dlp.version.__version__}: extractors whose test cases are mostly age_limit 18",
+             "domains": sorted(adult_dom), "extractors": sorted(adult_ie),
+             "note": "PornHub is excluded on purpose: it has its own plan rules, set by the operator."}
+    return {"ytdlp": yt_dlp.version.__version__, "sites": sites}, adult
+
+
+def build_page(data, out, MODE="all"):
+    """
+    MODE: "all"   - directory of every site, long tail covered by the other-sites rule
+          "paid"  - directory of every site, long tail on paid plans only
+          "major" - platforms with their own plan rule only; no directory
+    """
+    SITES = data["sites"]; YTDLP = data["ytdlp"]
+    N = len(SITES)
+    UPDATED_ISO = "2026-09-10"; UPDATED = "10 September 2026"
+    BASE = "https://www.gheychee.xyz"; URL = BASE + "/supported-sites.html"
+    BOT = "https://t.me/gheychipremium_bot"
+    fmt = lambda n: f"{n:,}"
+    e = html.escape
+
+    LONGTAIL_PLANS = {"all": "All plans, from the other-sites allowance",
+                      "paid": "Starter, Standard, Pro, from the other-sites allowance"}.get(MODE)
+
+    # What each platform returns and which plans carry a rule for it (plans.py defaults).
+    MAJOR = [
+      ("YouTube", "youtube.com", "Video, or the audio as MP3. Length is capped by plan.", "Starter, Standard, Pro"),
+      ("Instagram", "instagram.com", "Public reels and posts.", "All plans"),
+      ("X / Twitter", "x.com", "Video from public posts.", "All plans"),
+      ("TikTok", "tiktok.com", "Video.", "Standard, Pro"),
+      ("LinkedIn", "linkedin.com", "Video from public posts.", "All plans"),
+      ("Telegram, restricted", "t.me", "Posts, albums and forum topics, including channels that switch saving off.", "All plans"),
+      ("Facebook", "facebook.com", "Public video.", "Pro"),
+      ("Vimeo", "vimeo.com", "Video.", "Pro"),
+      ("SoundCloud", "soundcloud.com", "Audio.", "Starter, Standard, Pro"),
+      ("RadioJavan", "radiojavan.com", "Audio only. Video links are declined.", "Starter, Standard"),
+    ]
+    if LONGTAIL_PLANS:
+        MAJOR.append(("Reddit, Twitch, Dailymotion, Pinterest",
+                      None, f"Video. These and {fmt(N - 14)} more sites are in the A to Z list below.", LONGTAIL_PLANS))
+
+    site_count_phrase = (f"{fmt(N)} sites" if MODE != "major" else "the platforms below")
+    title = (f"Supported sites: every site Gheychi can download from ({fmt(N)})" if MODE != "major"
+             else "Supported sites and platforms | Gheychi Premium")
+    desc = (f"Every site the Gheychi Premium Telegram bot downloads from: YouTube, Instagram, TikTok, X, LinkedIn, "
+            f"restricted Telegram channels and {fmt(N - 6)} more. Updated {UPDATED}."
+            if MODE != "major" else
+            f"The platforms the Gheychi Premium Telegram bot downloads from, what each one returns, and which plans include it. Updated {UPDATED}.")
+
+    jsonld = {
+      "@context": "https://schema.org",
+      "@graph": [
+        {"@type": "WebPage", "@id": URL, "url": URL, "name": title, "description": desc,
+         "dateModified": UPDATED_ISO, "inLanguage": "en",
+         "isPartOf": {"@type": "WebSite", "name": "Gheychi Premium", "url": BASE + "/"},
+         "about": {"@id": BASE + "/#app"}, "breadcrumb": {"@id": URL + "#breadcrumb"}},
+        {"@type": "BreadcrumbList", "@id": URL + "#breadcrumb", "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": BASE + "/"},
+          {"@type": "ListItem", "position": 2, "name": "Supported sites", "item": URL}]},
+        {"@type": "SoftwareApplication", "@id": BASE + "/#app", "name": "Gheychi Premium",
+         "applicationCategory": "MultimediaApplication", "operatingSystem": "Telegram",
+         "url": BASE + "/", "sameAs": [BOT],
+         "offers": {"@type": "AggregateOffer", "priceCurrency": "USD", "lowPrice": "0", "highPrice": "23", "offerCount": "4"}},
+        {"@type": "ItemList", "name": "Major platforms supported by Gheychi Premium",
+         "numberOfItems": len([m for m in MAJOR if m[1]]),
+         "itemListElement": [{"@type": "ListItem", "position": i + 1, "name": m[0]} for i, m in enumerate(m for m in MAJOR if m[1])]},
+      ]}
+
+    groups = collections.OrderedDict()
+    for s in SITES:
+        k = s[0].upper() if s[0].isalpha() else "#"
+        groups.setdefault(k, []).append(s)
+    if "#" in groups: groups.move_to_end("#", last=False)
+    gid = lambda k: "dir-num" if k == "#" else f"dir-{k.lower()}"
+
+    def _dom(d):
+        return '<span class="dom">' + e(d) + '</span>' if d else ""
+    major_rows = "\n".join(
+      '          <tr><th scope="row">' + e(n) + _dom(d) + '</th><td>' + e(w) + '</td><td class="plans">' + e(p) + '</td></tr>'
+      for n, d, w, p in MAJOR)
+
+    directory = ""
+    if MODE != "major":
+        jump = "".join(f'<a href="#{gid(k)}">{e(k)}</a>' for k in groups)
+        body = "\n".join(
+          f'        <section class="dir-group" id="{gid(k)}" data-group>\n'
+          f'          <h3 class="dir-letter">{e(k)}</h3>\n'
+          f'          <ul>{"".join(f"<li>{e(s)}</li>" for s in v)}</ul>\n'
+          f'        </section>' for k, v in groups.items())
+        note_paid = (" The long tail needs a paid plan." if MODE == "paid" else "")
+        directory = f'''
+  <section class="band" aria-labelledby="h-dir">
+    <div class="wrap">
+      <div class="sec-rule"><span class="spec spec-ink">Directory</span><span class="spec">{fmt(N)} sites · yt-dlp {e(YTDLP)}</span></div>
+      <h2 class="t-h2" id="h-dir">Every supported site, A to Z</h2>
+      <p class="t-body" style="margin-top:1rem">This list is built from yt-dlp {e(YTDLP)}, the open-source download engine the bot runs, and includes every site with a working extractor in that version.{note_paid} Adult sites are left off this page.</p>
+      <p class="t-body">A site being listed means the bot knows how to read it. It does not mean every link from it will work: a post that needs you to sign in, a video blocked in some countries, or a site that changed its layout last week can still fail.</p>
+
+      <div class="dir-tools">
+        <label class="dir-filter" hidden data-filter-wrap>
+          <span class="spec spec-ink">Filter</span>
+          <input type="search" placeholder="Type a site, e.g. bandcamp" autocomplete="off" spellcheck="false" data-filter>
+        </label>
+        <p class="spec spec-plain" aria-live="polite" data-count>{fmt(N)} sites</p>
+      </div>
+      <nav class="dir-jump" aria-label="Jump to letter">{jump}</nav>
+
+      <div class="dir">
+{body}
+      </div>
+      <p class="spec spec-plain dir-empty" hidden data-empty>No site in the list matches that. It may still work: send the link to the bot and see.</p>
+    </div>
+  </section>'''
+
+    faq = [
+      ("What sites does Gheychi Premium support?",
+       (f"It downloads from {fmt(N)} sites. The main ones are YouTube, Instagram, X, TikTok, LinkedIn, Facebook, Vimeo, SoundCloud and RadioJavan, plus restricted Telegram channels. The rest come from yt-dlp, the open-source engine the bot runs on, and are listed A to Z on this page."
+        if MODE != "major" else
+        "YouTube, Instagram, X, TikTok, LinkedIn, Facebook, Vimeo, SoundCloud and RadioJavan, plus restricted Telegram channels. The table on this page shows what each one returns and which plans include it.")),
+      ("Can it download from a Telegram channel that blocks saving?",
+       "Yes, if the bot's account can see the channel. It runs a real Telegram user session, so content protection that stops forwarding and saving does not stop it. Public posts, private channels, groups and forum topics all work, including whole albums. Invite links that start with t.me/+ are not supported."),
+      ("Is there a file size limit?",
+       "Yes, 500 MB per file. Telegram limits bots to 50 MB per upload, so anything larger is sent through a Telegram user session instead and then copied into your chat. That takes a little longer, but the file arrives the same way."),
+      ("Why did a link from a listed site fail?",
+       "Usually because the video needs an account to watch, is blocked in the country the bot runs from, or is private. Sites also change their pages, and the engine needs an update to catch up. If a link fails, send it to /support in the bot and we will look at it."),
+      ("Does it work with Netflix, Spotify or Disney+?",
+       "No. Those services encrypt their streams with DRM, and the bot does not break that protection. The same goes for anything behind a paywall you would have to log in to."),
+      ("Is Gheychi Premium free?",
+       "There is a free plan with a monthly allowance on X, Instagram, LinkedIn, restricted Telegram and every other site in the A to Z list. It needs no card and no sign-up form; you start by opening the bot. Paid plans run from $5 to $23 a month and raise the allowances."),
+    ]
+    faq_html = "\n".join(
+      f'''        <div class="qa">
+          <h3>{e(q)}</h3>
+          <p>{e(a)}</p>
+        </div>''' for q, a in faq)
+
+    page = f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{e(title)}</title>
+<meta name="description" content="{e(desc)}">
+<link rel="canonical" href="{URL}">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Gheychi Premium">
+<meta property="og:title" content="{e(title)}">
+<meta property="og:description" content="{e(desc)}">
+<meta property="og:url" content="{URL}">
+<meta name="twitter:card" content="summary">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<script type="application/ld+json">{json.dumps(jsonld, ensure_ascii=False)}</script>
+<style>
+  /* The directory is a parts index: ruled letter heads over mono entries in
+     newspaper columns. Scoped here because no other page carries an index. */
+  .plat {{ width: 100%; border-collapse: collapse; }}
+  .plat th, .plat td {{ text-align: left; vertical-align: baseline; padding: .8125rem .75rem; border-bottom: 1px solid var(--rule-soft); }}
+  .plat thead th {{ font-family: var(--mono); font-size: .6875rem; font-weight: 600; letter-spacing: .13em; text-transform: uppercase; color: var(--ink-3); border-bottom-color: var(--rule); white-space: nowrap; }}
+  .plat th:first-child, .plat td:first-child {{ padding-left: 0; }}
+  .plat th:last-child, .plat td:last-child {{ padding-right: 0; }}
+  .plat tbody th {{ font-weight: 600; color: var(--ink); font-size: .9375rem; white-space: nowrap; }}
+  .plat .dom {{ display: block; font-family: var(--mono); font-size: .6875rem; font-weight: 400; color: var(--ink-3); margin-top: .125rem; }}
+  .plat td {{ color: var(--ink-2); font-size: .9375rem; }}
+  .plat td.plans {{ font-family: var(--mono); font-size: .75rem; color: var(--ink); white-space: nowrap; }}
+  .plat tbody tr:hover > * {{ background: var(--paper-2); }}
+  .table-scroll {{ overflow-x: auto; }}
+
+  .glance {{ max-width: 34rem; }}
+
+  .dir-tools {{ display: flex; flex-wrap: wrap; align-items: end; gap: .75rem 1.5rem; margin-top: 2rem; }}
+  .dir-filter {{ display: grid; gap: .375rem; flex: 1 1 18rem; max-width: 26rem; }}
+  .dir-filter input {{
+    font: 500 .9375rem/1.2 var(--mono); color: var(--ink); background: var(--paper);
+    border: 1px solid var(--rule); border-radius: var(--radius); padding: .6875rem .75rem;
+  }}
+  .dir-filter input:focus-visible {{ outline: 2px solid var(--signal); outline-offset: 1px; border-color: var(--signal); }}
+  .dir-jump {{ display: flex; flex-wrap: wrap; gap: .25rem; margin-top: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--rule); }}
+  .dir-jump a {{
+    font-family: var(--mono); font-size: .75rem; font-weight: 600; min-width: 1.75rem; text-align: center;
+    padding: .3125rem .25rem; color: var(--ink-2); text-decoration: none; border: 1px solid var(--rule-soft); border-radius: 2px;
+  }}
+  .dir-jump a:hover {{ color: var(--signal-deep); border-color: var(--signal); }}
+  .dir {{ columns: 13rem auto; column-gap: 2rem; margin-top: 1.5rem; }}
+  .dir-group {{ margin-bottom: 1.25rem; scroll-margin-top: 5rem; }}
+  .dir-letter {{
+    font-family: var(--mono); font-size: .75rem; font-weight: 600; letter-spacing: .13em; color: var(--signal-deep);
+    border-bottom: 1px solid var(--rule); padding-bottom: .25rem; margin-bottom: .375rem; break-after: avoid;
+  }}
+  .dir-group ul {{ list-style: none; margin: 0; padding: 0; }}
+  .dir-group li {{ font-family: var(--mono); font-size: .8125rem; line-height: 1.85; color: var(--ink-2); overflow-wrap: anywhere; }}
+  .dir-empty {{ margin-top: 1rem; }}
+
+  .faq {{ display: grid; gap: 0; border-top: 1px solid var(--rule); }}
+  .qa {{ padding: 1.375rem 0; border-bottom: 1px solid var(--rule-soft); display: grid; gap: .5rem; }}
+  @media (min-width: 780px) {{ .qa {{ grid-template-columns: 22rem 1fr; gap: 2rem; align-items: baseline; }} }}
+  .qa h3 {{ font-size: 1rem; letter-spacing: -0.015em; text-wrap: balance; }}
+  .qa p {{ color: var(--ink-2); font-size: .9375rem; max-width: 64ch; }}
+</style>
+</head>
+<body>
+<a class="sr-only" href="#main">Skip to content</a>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+  <defs>
+    <g id="i-scissors" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/>
+      <line x1="20" y1="4" x2="8.12" y2="15.88"/><line x1="14.47" y1="14.48" x2="20" y2="20"/><line x1="8.12" y1="8.12" x2="12" y2="12"/>
+    </g>
+    <g id="i-send" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M22 2 11 13"/><path d="M22 2 15 22l-4-9-9-4Z"/>
+    </g>
+    <g id="i-lock" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="4" y="10" width="16" height="11" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/>
+    </g>
+    <g id="i-audio" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/>
+    </g>
+    <g id="i-gauge" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 14 16 9"/><circle cx="12" cy="14" r="1"/><path d="M3.5 17a9 9 0 1 1 17 0"/>
+    </g>
+    <g id="i-langs" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 5h10"/><path d="M8 3v2c0 4.5-2 7-5 8"/><path d="M5 10c1.5 2.5 3.5 4 6 5"/><path d="M12 21l4.5-10 4.5 10"/><path d="M14 17h5"/>
+    </g>
+    <g id="i-shield" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"/>
+    </g>
+    <g id="i-check" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="m4 12 5.5 5.5L20 7"/>
+    </g>
+    <g id="i-menu" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+      <path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/>
+    </g>
+  </defs>
+</svg>
+
+<header class="nav">
+  <div class="wrap nav-in">
+    <a class="brand" href="index.html">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-scissors"/></svg>
+      <span class="stack-s" style="gap:0">
+        <b>Gheychi Premium</b>
+        <span>Media tool · TG</span>
+      </span>
+    </a>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="features.html">Capabilities</a>
+      <a href="pricing.html">Plans</a>
+      <a href="about-product.html">Roadmap</a>
+      <a href="about-us.html">About</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <a class="btn btn-signal btn-sm nav-cta" href="{BOT}" target="_blank" rel="noopener">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-send"/></svg> Open bot
+    </a>
+    <button class="nav-toggle" data-nav-toggle aria-expanded="false" aria-label="Open menu" aria-controls="navdrawer">
+      <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true"><use href="#i-menu"/></svg>
+    </button>
+  </div>
+  <div class="nav-drawer" id="navdrawer" data-nav-drawer>
+    <div class="wrap">
+      <a href="features.html">Capabilities</a>
+      <a href="pricing.html">Plans</a>
+      <a href="about-product.html">Roadmap</a>
+      <a href="about-us.html">About</a>
+      <a href="contact.html">Contact</a>
+    </div>
+  </div>
+</header>
+
+<main id="main">
+  <section class="wrap" style="padding-block: clamp(2.25rem,5.5vw,3.75rem)">
+    <div class="sec-rule"><span class="spec spec-ink">Supported sites</span><span class="spec">Updated <time datetime="{UPDATED_ISO}">{UPDATED}</time></span></div>
+    <div class="cols cols-2" style="align-items:end">
+      <div class="stack">
+        <h1 class="t-display" style="font-size:clamp(2.25rem,6vw,4rem)">Every site Gheychi can download from</h1>
+        <p class="t-lead">Gheychi Premium is a Telegram bot that downloads video and audio from a link. It works with {site_count_phrase}, including YouTube, Instagram, X, TikTok and LinkedIn, and it can read Telegram channels that switch saving off. Send the link to <a href="{BOT}" target="_blank" rel="noopener">@gheychipremium_bot</a> and the file comes back in the same chat.</p>
+        <div class="row" style="margin-top:.5rem">
+          <a class="btn btn-signal" href="{BOT}" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-send"/></svg> Open the bot</a>
+          <a class="btn btn-line" href="pricing.html">Compare plans</a>
+        </div>
+      </div>
+      <dl class="specs glance">
+        <div class="spec-row"><dt>Sites supported</dt><span class="leader"></span><dd>{fmt(N) if MODE != "major" else str(len([m for m in MAJOR if m[1]]))}</dd></div>
+        <div class="spec-row"><dt>Largest file</dt><span class="leader"></span><dd>500 MB</dd></div>
+        <div class="spec-row"><dt>Audio as MP3</dt><span class="leader"></span><dd>yes</dd></div>
+        <div class="spec-row"><dt>Account needed</dt><span class="leader"></span><dd>no</dd></div>
+        <div class="spec-row"><dt>Files kept on the server</dt><span class="leader"></span><dd>&lt; 1 hr</dd></div>
+        <div class="spec-row"><dt>Download engine</dt><span class="leader"></span><dd>yt-dlp {e(YTDLP)}</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <section class="band band-tight" aria-labelledby="h-plat">
+    <div class="wrap">
+      <div class="sec-rule"><span class="spec spec-ink">Platforms</span><span class="spec">What comes back, and on which plan</span></div>
+      <h2 class="t-h2" id="h-plat">Which platforms are supported?</h2>
+      <p class="t-body" style="margin-top:1rem">These are the platforms people send most. Each one is counted separately against your plan, so a busy week on YouTube does not use up your Instagram allowance.</p>
+      <div class="table-scroll" style="margin-top:1.5rem">
+        <table class="plat">
+          <thead><tr><th scope="col">Platform</th><th scope="col">What you get</th><th scope="col">Plans</th></tr></thead>
+          <tbody>
+{major_rows}
+          </tbody>
+        </table>
+      </div>
+      <p class="spec spec-plain" style="margin-top:1rem">Allowances per plan are on the <a href="pricing.html">plans page</a>.</p>
+    </div>
+  </section>
+
+  <section class="band" aria-labelledby="h-why">
+    <div class="wrap cols cols-doc" style="align-items:start">
+      <div class="stack">
+        <div class="sec-rule"><span class="spec spec-ink">Why Gheychi</span></div>
+        <h2 class="t-h2" id="h-why" style="font-size:clamp(1.5rem,2.8vw,2.125rem)">Why use a Telegram bot instead of a downloader website?</h2>
+        <p class="t-body">Downloader websites put a page, and usually a stack of ads, between you and the file. Gheychi works from inside Telegram, where you already are, and does a few things those sites cannot.</p>
+      </div>
+      <div class="caps">
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-lock"/></svg></span>
+          <h3>Reads channels that block saving</h3>
+          <p>Many Telegram channels switch off forwarding and saving. The bot runs a real Telegram user session, so it can still read those posts, as long as its account can see the channel. Albums come through whole.</p>
+        </div>
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-send"/></svg></span>
+          <h3>No site, no app, no ads</h3>
+          <p>You paste a link into a chat and the file arrives in that chat. There is nothing to install, no page full of pop-ups, and no fake download buttons to avoid.</p>
+        </div>
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-gauge"/></svg></span>
+          <h3>Files up to 500 MB</h3>
+          <p>Telegram stops bots at 50 MB per upload. Larger files go through a user session and are copied to you, so a long video still arrives instead of failing halfway.</p>
+        </div>
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-shield"/></svg></span>
+          <h3>Nothing stays on the server</h3>
+          <p>The bot keeps a temporary copy only while it sends the file, and deletes it within the hour. Your history is a list of links you sent, not a library of your files.</p>
+        </div>
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-audio"/></svg></span>
+          <h3>Pick the quality, or just the audio</h3>
+          <p>Choose a resolution before the download starts, or take the soundtrack as an MP3.</p>
+        </div>
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-langs"/></svg></span>
+          <h3>English and Persian</h3>
+          <p>The whole bot works in either language. Switch any time with /lang.</p>
+        </div>
+        <div class="cap">
+          <span class="cap-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-check"/></svg></span>
+          <h3>Free to start</h3>
+          <p>The free plan needs no card and no sign-up form. Open the bot and send a link.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+{directory}
+
+  <section class="band" aria-labelledby="h-faq">
+    <div class="wrap">
+      <div class="sec-rule"><span class="spec spec-ink">Questions</span></div>
+      <h2 class="t-h2" id="h-faq">Questions about supported sites</h2>
+      <div class="faq" style="margin-top:1.5rem">
+{faq_html}
+      </div>
+    </div>
+  </section>
+
+  <section class="band band-plate" aria-labelledby="h-go">
+    <div class="wrap row" style="justify-content:space-between;gap:1.5rem">
+      <div class="stack-s">
+        <h2 class="t-h3" id="h-go">Not sure your site works? Send the link and find out.</h2>
+        <p class="t-body">The free plan is enough to try it.</p>
+      </div>
+      <a class="btn btn-signal" href="{BOT}" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-send"/></svg> Open @gheychipremium_bot</a>
+    </div>
+  </section>
+</main>
+
+<footer class="foot">
+  <div class="wrap">
+    <div class="foot-grid">
+      <div>
+        <a class="brand" href="index.html">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-scissors"/></svg>
+          <span class="stack-s" style="gap:0"><b>Gheychi Premium</b><span>Media tool · TG</span></span>
+        </a>
+        <p class="foot-note">A media downloader that lives in Telegram, including the channels other tools cannot reach.</p>
+      </div>
+      <div class="foot-col">
+        <p class="foot-title">Product</p>
+        <a href="features.html">Capabilities</a>
+        <a href="supported-sites.html">Supported sites</a>
+        <a href="pricing.html">Plans</a>
+        <a href="about-product.html">Roadmap</a>
+      </div>
+      <div class="foot-col">
+        <p class="foot-title">Company</p>
+        <a href="about-us.html">About</a>
+        <a href="contact.html">Contact</a>
+      </div>
+      <div class="foot-col">
+        <p class="foot-title">Legal</p>
+        <a href="privacy.html">Privacy</a>
+        <a href="terms.html">Terms</a>
+      </div>
+    </div>
+    <div class="foot-base">
+      <span class="spec spec-plain">© 2026 Gheychi Premium</span>
+      <span class="spec spec-plain">gheychee.xyz · @gheychipremium_bot</span>
+    </div>
+  </div>
+</footer>
+
+<script src="script.js"></script>
+<script>
+  // Filtering is an enhancement: the full list is in the HTML for readers and
+  // crawlers, and the control only appears once this script can drive it.
+  (function () {{
+    var input = document.querySelector('[data-filter]');
+    if (!input) return;
+    document.querySelector('[data-filter-wrap]').hidden = false;
+    var groups = [].slice.call(document.querySelectorAll('[data-group]'));
+    var count = document.querySelector('[data-count]');
+    var empty = document.querySelector('[data-empty]');
+    var total = {N};
+    input.addEventListener('input', function () {{
+      var q = input.value.trim().toLowerCase(), shown = 0;
+      groups.forEach(function (g) {{
+        var any = false;
+        [].forEach.call(g.querySelectorAll('li'), function (li) {{
+          var hit = !q || li.textContent.indexOf(q) !== -1;
+          li.hidden = !hit; if (hit) {{ any = true; shown++; }}
+        }});
+        g.hidden = !any;
+      }});
+      count.textContent = q ? shown.toLocaleString('en') + ' of ' + total.toLocaleString('en') + ' sites' : total.toLocaleString('en') + ' sites';
+      empty.hidden = shown !== 0;
+    }});
+  }})();
+</script>
+</body>
+</html>
+'''
+    open(out, "w").write(page)
+    return N
+
+
+if __name__ == "__main__":
+    root = pathlib.Path(__file__).resolve().parent.parent
+    data, adult = extract()
+    with open(root / "adult_sites.json", "w") as f:
+        json.dump(adult, f, ensure_ascii=False, indent=1)
+    n = build_page(data, str(root / "website" / "supported-sites.html"), "all")
+    print(f"yt-dlp {data['ytdlp']}: {n:,} sites, {len(adult['domains'])} adult domains, "
+          f"{len(adult['extractors'])} adult extractors")

--- a/website/supported-sites.html
+++ b/website/supported-sites.html
@@ -65,16 +65,6 @@
 </style>
 </head>
 <body>
-<!--
-THESIS: The supported-sites page is the catalogue's parts index: a spec table for
-the platforms that matter, then every site set in mono columns under ruled letters.
-OWN-WORLD: Paper #EFEFEA, ink #16160F, signal orange #D63C0B for letter heads and
-actions only. Archivo for voice, JetBrains Mono for every domain and figure.
-STORY: The visitor checks whether their site is covered, sees what they get and on
-which plan, reads why this beats a downloader website, then opens the bot.
-FIRST VIEWPORT: Title, a direct answer in the first sentence, an at-a-glance spec list.
-FORM: Precision instrument / engineering trade catalogue; seed dd384b0b.
--->
 <a class="sr-only" href="#main">Skip to content</a>
 
 <svg width="0" height="0" style="position:absolute" aria-hidden="true">
@@ -336,7 +326,7 @@ FORM: Precision instrument / engineering trade catalogue; seed dd384b0b.
         </section>
         <section class="dir-group" id="dir-s" data-group>
           <h3 class="dir-letter">S</h3>
-          <ul><li>s4c.cymru</li><li>saavn.com</li><li>sachsen.de</li><li>safaribooksonline.com</li><li>saktv.ch</li><li>salt.ch</li><li>samplefocus.com</li><li>sandia.gov</li><li>sapo.pt</li><li>sat7plus.org</li><li>sauceplus.com</li><li>sba.sa</li><li>sbnation.com</li><li>sbs.co.kr</li><li>sbs.com.au</li><li>schooltv.nl</li><li>sciebo.de</li><li>sciencechannel.com</li><li>screen9.com</li><li>screen9.tv</li><li>screencast-o-matic.com</li><li>screencast.com</li><li>screencastify.com</li><li>screenrec.com</li><li>scrolller.com</li><li>sen.com</li><li>senate.gov</li><li>seriesplus.com</li><li>servus.com</li><li>servustv.com</li><li>seznam.cz</li><li>seznamzpravy.cz</li><li>sharepoint.com</li><li>shemaroome.com</li><li>shiey.com</li><li>showcase.ca</li><li>showroom-live.com</li><li>silenticetv.com</li><li>simplecast.com</li><li>sina.com.cn</li><li>sjearthquakes.com</li><li>skaties.lv</li><li>skeb.jp</li><li>sky.com</li><li>sky.it</li><li>skynews.com.au</li><li>skysports.com</li><li>slideshare.net</li><li>slideslive.com</li><li>slipfox.xyz</li><li>smotrim.ru</li><li>snagfilms.com</li><li>snapchat.com</li><li>softwhiteunderbelly.com</li><li>sohu.com</li><li>sonyliv.com</li><li>sooplive.com</li><li>soundcloud.com</li><li>soundersfc.com</li><li>soundgasm.net</li><li>southpark.de</li><li>southpark.lat</li><li>southparkstudios.co.uk</li><li>southparkstudios.com</li><li>southparkstudios.com.br</li><li>southparkstudios.nu</li><li>sovietscloset.com</li><li>spankbang.com</li><li>spiegel.de</li><li>sport1tv.ru</li><li>sport5.co.il</li><li>sporteurope.tv</li><li>sportingkc.com</li><li>sportschau.de</li><li>sporza.be</li><li>spreaker.com</li><li>sproutvideo.com</li><li>sr-mediathek.de</li><li>srf.ch</li><li>stacommu.jp</li><li>stage-plus.com</li><li>startrek.com</li><li>startv.com.tr</li><li>starwars.com</li><li>steamcommunity.com</li><li>steampowered.com</li><li>storyfire.com</li><li>streaks.jp</li><li>stream.cz</li><li>stream.new</li><li>streamable.com</li><li>streetvoice.com</li><li>stv.tv</li><li>stvr.sk</li><li>su.se</li><li>subspla.sh</li><li>subsplash.com</li><li>substack.com</li><li>sundancetv.com</li><li>sverigesradio.se</li><li>svt.se</li><li>svtplay.se</li><li>swipeto.pl</li><li>swissinfo.ch</li><li>syfy.com</li><li>sztv.hu</li></ul>
+          <ul><li>s4c.cymru</li><li>saavn.com</li><li>sachsen.de</li><li>safaribooksonline.com</li><li>saktv.ch</li><li>salt.ch</li><li>samplefocus.com</li><li>sandia.gov</li><li>sapo.pt</li><li>sat7plus.org</li><li>sauceplus.com</li><li>sba.sa</li><li>sbnation.com</li><li>sbs.co.kr</li><li>sbs.com.au</li><li>schooltv.nl</li><li>sciebo.de</li><li>sciencechannel.com</li><li>screen9.com</li><li>screen9.tv</li><li>screencast-o-matic.com</li><li>screencast.com</li><li>screencastify.com</li><li>screenrec.com</li><li>scrolller.com</li><li>sen.com</li><li>senate.gov</li><li>seriesplus.com</li><li>servus.com</li><li>servustv.com</li><li>seznam.cz</li><li>seznamzpravy.cz</li><li>sharepoint.com</li><li>shemaroome.com</li><li>shiey.com</li><li>showcase.ca</li><li>showroom-live.com</li><li>silenticetv.com</li><li>simplecast.com</li><li>sina.com.cn</li><li>sjearthquakes.com</li><li>skaties.lv</li><li>skeb.jp</li><li>sky.com</li><li>sky.it</li><li>skynews.com.au</li><li>skysports.com</li><li>slideshare.net</li><li>slideslive.com</li><li>smotrim.ru</li><li>snagfilms.com</li><li>snapchat.com</li><li>softwhiteunderbelly.com</li><li>sohu.com</li><li>sonyliv.com</li><li>sooplive.com</li><li>soundcloud.com</li><li>soundersfc.com</li><li>soundgasm.net</li><li>southpark.de</li><li>southpark.lat</li><li>southparkstudios.co.uk</li><li>southparkstudios.com</li><li>southparkstudios.com.br</li><li>southparkstudios.nu</li><li>sovietscloset.com</li><li>spankbang.com</li><li>spiegel.de</li><li>sport1tv.ru</li><li>sport5.co.il</li><li>sporteurope.tv</li><li>sportingkc.com</li><li>sportschau.de</li><li>sporza.be</li><li>spreaker.com</li><li>sproutvideo.com</li><li>sr-mediathek.de</li><li>srf.ch</li><li>stacommu.jp</li><li>stage-plus.com</li><li>startrek.com</li><li>startv.com.tr</li><li>starwars.com</li><li>steamcommunity.com</li><li>steampowered.com</li><li>storyfire.com</li><li>streaks.jp</li><li>stream.cz</li><li>stream.new</li><li>streamable.com</li><li>streetvoice.com</li><li>stv.tv</li><li>stvr.sk</li><li>su.se</li><li>subspla.sh</li><li>subsplash.com</li><li>substack.com</li><li>sundancetv.com</li><li>sverigesradio.se</li><li>svt.se</li><li>svtplay.se</li><li>swipeto.pl</li><li>swissinfo.ch</li><li>syfy.com</li><li>sztv.hu</li></ul>
         </section>
         <section class="dir-group" id="dir-t" data-group>
           <h3 class="dir-letter">T</h3>
@@ -344,7 +334,7 @@ FORM: Precision instrument / engineering trade catalogue; seed dd384b0b.
         </section>
         <section class="dir-group" id="dir-u" data-group>
           <h3 class="dir-letter">U</h3>
-          <ul><li>u-strasbg.fr</li><li>udemy.com</li><li>udn.com</li><li>uib.no</li><li>uliza.jp</li><li>ulizaportal.jp</li><li>ultimedia.com</li><li>un.org</li><li>uni-muenster.de</li><li>unistra.fr</li><li>united.cloud</li><li>univ-sba.dz</li><li>universal-music.de</li><li>uol.com.br</li><li>uplynk.com</li><li>upskillcourses.com</li><li>urplay.se</li><li>urskola.se</li><li>usanetwork.com</li><li>usatoday.com</li><li>ustream.tv</li><li>ustudio.com</li></ul>
+          <ul><li>u-strasbg.fr</li><li>udemy.com</li><li>udn.com</li><li>uib.no</li><li>uliza.jp</li><li>ulizaportal.jp</li><li>ultimedia.com</li><li>un.org</li><li>uni-muenster.de</li><li>unistra.fr</li><li>united.cloud</li><li>univ-sba.dz</li><li>universal-music.de</li><li>unofficialbird.com</li><li>uol.com.br</li><li>uplynk.com</li><li>upskillcourses.com</li><li>urplay.se</li><li>urskola.se</li><li>usanetwork.com</li><li>usatoday.com</li><li>ustream.tv</li><li>ustudio.com</li></ul>
         </section>
         <section class="dir-group" id="dir-v" data-group>
           <h3 class="dir-letter">V</h3>


### PR DESCRIPTION
Every item still marked **Ready to do** on the Gheychee Board that can be done in code.

## Plan and quota belong to the account (model C, phase 2)
- A linked Telegram ID gets the best active plan among the IDs on its account, so paying on one covers the others.
- All linked IDs draw on one quota pool, the other-sites allowance included.
- `usage_events.account_id` is stamped when each event is recorded, so unlinking can't hand usage back and linking can't reset a spent allowance.
- An expired plan no longer counts toward the slot cap.
- IDs that aren't linked to any account behave exactly as before.
- The plan column stays on `bot_users`; see the commit message for why.

## YouTube quota alert
When the provider's daily units drop to 100, the bot posts once a day to the backup channel. It is best effort and never blocks a download.

## Supported-sites generator
`tools/build_supported_sites.py` now lives in the repo. It is seeded and reproducible, and it reproduces `adult_sites.json` exactly.

## Design comments
Moved out of the shipped HTML into DESIGN.md under "Page contracts".

## Verified
- 73/73 tests, 7 of them new for the pool.
- Generator output is identical across runs.
- Alert behaviour checked with a stubbed sender.

## Deploy note
On first boot, `init_logs_db` adds `usage_events.account_id` and stamps the existing rows once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)